### PR TITLE
Add type manipulation for numbers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,14 @@ export const TEXT = {
   REQUIRED: 'This is required'
 };
 
-export function getSpecTypeValue(value, specType: 'date' | 'boolean' | 'text') {
+export function getSpecTypeValue(value, specType: 'date' | 'number' | 'boolean' | 'text') {
   switch (specType) {
     case 'date':
       return Number(value);
     case 'boolean':
       return value === 'on' || value === 'true';
+    case 'number':
+      return +value;
 
     default:
       return value;

--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,10 @@ export function getSpecTypeValue(value, specType: 'date' | 'number' | 'boolean' 
   switch (specType) {
     case 'date':
       return Number(value);
-    case 'boolean':
-      return value === 'on' || value === 'true';
     case 'number':
       return +value;
+    case 'boolean':
+      return value === 'on' || value === 'true';
 
     default:
       return value;

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export function getSpecTypeValue(value, specType: 'date' | 'number' | 'boolean' 
     case 'date':
       return Number(value);
     case 'number':
-      return +value;
+      return Number(value);
     case 'boolean':
       return value === 'on' || value === 'true';
 


### PR DESCRIPTION
Currently, there isn't a way to convert form data from string to integer. So added the provision to do so.